### PR TITLE
fix(watchlist) / implement watchlist limit

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,10 +21,11 @@ const movies: Movie[] = JSON
  * * * * *  Add shows and movies to watchlist  * * * * *
  */
 const showWatchlist = shows
-    .map((serie) => ({
+    .filter((show) => show.status === "not_started_yet")
+    .map((show) => ({
         ids: {
-            tvdb: serie.id.tvdb,
-            imdb: serie.id.imdb === "-1" ? "" : serie.id.imdb,
+            tvdb: show.id.tvdb,
+            imdb: show.id.imdb === "-1" ? "" : show.id.imdb,
             slug: "",
             tmdb: -Infinity,
             trakt: -Infinity,

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ const showWatchlist = shows
     }));
 
 const movieWatchlist = movies
+    .filter((movie) => !movie.is_watched)
     .map((movie) => ({
         watched_at: movie.watched_at,
         ids: {

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,30 @@
 import { readFile } from "fs/promises";
+import { stdin as input, stdout as output } from "process";
+import { createInterface } from "readline";
 import { LIBERATOR_EXPORT_PATH } from "./src/env/LIBERATOR_EXPORT_PATH";
 import { rateLimit, client as trakt } from "./src/trakt/client";
 import type { Movie, Show } from "./src/types";
+import { limit } from "./src/vip/limit";
+import { logVipError } from "./src/vip/logVipError";
 
 async function traktUnlimited() {
     await rateLimit();
     return trakt;
 }
+
+async function promptUser(question: string): Promise<void> {
+    const readline = createInterface({ input, output });
+    return new Promise((resolve) => {
+        readline.question(question, () => {
+            readline.close();
+            resolve();
+        });
+    });
+}
+
+const { user } = await traktUnlimited()
+    .then((trakt) => trakt.users.settings())
+    .then(async (response) => await response.json());
 
 /**
  * * * * *  Read liberator data  * * * * *
@@ -44,17 +62,34 @@ const movieWatchlist = movies
         },
     }));
 
-await traktUnlimited()
-    .then((trakt) =>
-        trakt.sync.watchlist.add({
-            shows: showWatchlist,
-            movies: movieWatchlist,
-        })
-    )
-    .then(async (response) => {
-        console.log("--- Imported watchlist: ", await response.text());
-    });
+const watchlistLength = showWatchlist.length + movieWatchlist.length;
+const listLimit = limit(user.vip);
 
+if (watchlistLength > listLimit) {
+    logVipError(
+        user.vip,
+        showWatchlist.length,
+        movieWatchlist.length,
+    );
+
+    await promptUser("Press Enter to continue importing your watch history...");
+} else {
+    await traktUnlimited()
+        .then((trakt) =>
+            trakt.sync.watchlist.add({
+                shows: showWatchlist,
+                movies: movieWatchlist,
+            })
+        )
+        .then(async (response) => {
+            console.log("--- Imported watchlist: ", await response.text());
+        });
+}
+
+console.log(`--- Proceeding to import watch history...`);
+console.log(
+    `--- This may take a while depending on the size of your watch history...`,
+);
 /**
  * * * * *  Add show and movie watches to history  * * * * *
  */
@@ -84,6 +119,16 @@ const showHistory = shows
 const movieHistory = movieWatchlist
     .filter((movie) => movie.watched_at != null);
 
+const episodeCount = showHistory.reduce(
+    (accShow, show) =>
+        accShow + show.seasons.reduce((accSeason, season) =>
+            accSeason + season.episodes.length, 0),
+    0,
+);
+
+console.log(
+    `--- Adding ${episodeCount} episodes and ${movieHistory.length} movies to watch history...`,
+);
 await traktUnlimited()
     .then((trakt) =>
         trakt.sync.history.add({

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import { LIBERATOR_EXPORT_PATH } from './src/env/LIBERATOR_EXPORT_PATH';
-import { rateLimit, client as trakt } from './src/trakt/client';
-import type { Movie, Show } from './src/types';
-import { readFile } from 'fs/promises';
+import { readFile } from "fs/promises";
+import { LIBERATOR_EXPORT_PATH } from "./src/env/LIBERATOR_EXPORT_PATH";
+import { rateLimit, client as trakt } from "./src/trakt/client";
+import type { Movie, Show } from "./src/types";
 
 async function traktUnlimited() {
     await rateLimit();
@@ -12,72 +12,67 @@ async function traktUnlimited() {
  * * * * *  Read liberator data  * * * * *
  */
 const shows: Show[] = JSON
-    .parse(await readFile(`${LIBERATOR_EXPORT_PATH}/shows.json`, 'utf-8'));
+    .parse(await readFile(`${LIBERATOR_EXPORT_PATH}/shows.json`, "utf-8"));
 
 const movies: Movie[] = JSON
-    .parse(await readFile(`${LIBERATOR_EXPORT_PATH}/movies.json`, 'utf-8'));
+    .parse(await readFile(`${LIBERATOR_EXPORT_PATH}/movies.json`, "utf-8"));
 
 /**
  * * * * *  Add shows and movies to watchlist  * * * * *
  */
 const showWatchlist = shows
-    .map(serie => ({
+    .map((serie) => ({
         ids: {
             tvdb: serie.id.tvdb,
-            imdb: serie.id.imdb === '-1'
-                ? ''
-                : serie.id.imdb,
-            slug: '',
+            imdb: serie.id.imdb === "-1" ? "" : serie.id.imdb,
+            slug: "",
             tmdb: -Infinity,
             trakt: -Infinity,
         },
     }));
 
 const movieWatchlist = movies
-    .map(movie => ({
+    .map((movie) => ({
         watched_at: movie.watched_at,
         ids: {
             imdb: movie.id.imdb,
-            slug: '',
+            slug: "",
             tmdb: -Infinity,
             trakt: -Infinity,
         },
     }));
 
 await traktUnlimited()
-    .then(trakt =>
+    .then((trakt) =>
         trakt.sync.watchlist.add({
             shows: showWatchlist,
             movies: movieWatchlist,
-
-        }),
+        })
     )
-    .then(async response => {
-        console.log('--- Imported watchlist: ', await response.text());
+    .then(async (response) => {
+        console.log("--- Imported watchlist: ", await response.text());
     });
 
 /**
  * * * * *  Add show and movie watches to history  * * * * *
  */
 const showHistory = shows
-    .map(show => ({
+    .map((show) => ({
         ids: {
             tvdb: show.id.tvdb,
-            imdb: show.id.imdb === '-1'
-                ? ''
-                : show.id.imdb,
-            slug: '',
+            imdb: show.id.imdb === "-1" ? "" : show.id.imdb,
+            slug: "",
             tmdb: -Infinity,
             trakt: -Infinity,
         },
         seasons: show
             .seasons
-            .map(season => ({
+            .map((season) => ({
                 number: season.number,
                 episodes: season
                     .episodes
-                    .filter(episode => episode.is_watched)
-                    .map(episode => ({
+                    .filter((episode) => episode.is_watched)
+                    .map((episode) => ({
                         watched_at: episode.watched_at,
                         number: episode.number,
                     })),
@@ -85,69 +80,73 @@ const showHistory = shows
     }));
 
 const movieHistory = movieWatchlist
-    .filter(movie => movie.watched_at != null);
+    .filter((movie) => movie.watched_at != null);
 
 await traktUnlimited()
-    .then(trakt =>
+    .then((trakt) =>
         trakt.sync.history.add({
             /**
              * Library typings are not compliant with Trakt Apiary documentation.
-             * 
+             *
              * See: https://trakt.docs.apiary.io/#reference/sync/add-to-history/add-items-to-watched-history
              */
             // @ts-expect-error
             shows: showHistory,
             movies: movieHistory,
-        }),
+        })
     )
-    .then(async response => {
-        console.log('--- Imported watch history: ', await response.text());
+    .then(async (response) => {
+        console.log("--- Imported watch history: ", await response.text());
     });
 
 /***
  * * * * *  Add stopped shows to hidden sections  * * * * *
  */
 const stoppedShows = shows
-    .filter(show => show.status === 'stopped')
-    .map(show => ({
+    .filter((show) => show.status === "stopped")
+    .map((show) => ({
         ids: {
             tvdb: show.id.tvdb,
-            imdb: show.id.imdb === '-1'
-                ? ''
-                : show.id.imdb,
-            slug: '',
+            imdb: show.id.imdb === "-1" ? "" : show.id.imdb,
+            slug: "",
             tmdb: -Infinity,
             trakt: -Infinity,
-        }
+        },
     }));
 
 await traktUnlimited()
-    .then(trakt =>
+    .then((trakt) =>
         trakt
             .users
             .requests
             .hidden
             .add({
                 shows: stoppedShows,
-                section: 'progress_watched',
+                section: "progress_watched",
             })
-            .then(async response => {
-                console.log('--- Stopped shows hiiden from progress: ', await response.text());
+            .then(async (response) => {
+                console.log(
+                    "--- Stopped shows hiiden from progress: ",
+                    await response.text(),
+                );
             })
     );
 
 await traktUnlimited()
-    .then(trakt =>
+    .then((trakt) =>
         trakt
             .users
             .requests
             .hidden
             .add({
                 shows: stoppedShows,
-                section: 'recommendations',
+                section: "recommendations",
             })
-            .then(async response => {
-                console.log('--- Stopped shows hidden from recommendations: ', await response.text());
+            .then(async (response) => {
+                console.log(
+                    "--- Stopped shows hidden from recommendations: ",
+                    await response.text(),
+                );
             })
     );
 

--- a/src/vip/limit.ts
+++ b/src/vip/limit.ts
@@ -1,0 +1,3 @@
+export function limit(vip: boolean): number {
+    return vip ? 10000 : 100;
+}

--- a/src/vip/logVipError.ts
+++ b/src/vip/logVipError.ts
@@ -1,0 +1,26 @@
+import { limit } from "./limit";
+
+export function logVipError(
+    vip: boolean,
+    showsCount: number,
+    moviesCount: number,
+) {
+    console.error("\n❌ WATCHLIST IMPORT FAILED");
+    console.error(`\n⚠️  Your watchlist exceeds the limit:`);
+    console.error(`   Shows: ${showsCount}`);
+    console.error(`   Movies: ${moviesCount}`);
+    console.error(`   Total: ${showsCount + moviesCount}`);
+    console.error(
+        `   Limit: ${limit(vip)} items (${vip ? "VIP" : "FREE"} tier)`,
+    );
+
+    if (!vip) {
+        console.error(`💡 Trakt VIP members get a 10,000 item limit!`);
+        console.error(
+            `   Consider upgrading your account: https://trakt.tv/vip\n`,
+        );
+    }
+    console.error(
+        `\n⏭️  Skipping watchlist import and proceeding with watch history...\n`,
+    );
+}


### PR DESCRIPTION
Overview:

This PR will implement a watchlist limit and error handling to prevent exceeding the Trakt API's rate limits, especially for free tier users. It also ensures that the watchlist only includes shows that have not started and unwatched movies.

Changes:

*   Introduced a VIP tier check.
*   Added a function `limit` to determine the item limit based on VIP status.
*   Filtered shows to include only those with "not\_started\_yet" status in the watchlist.
*   Filtered movies to exclude watched movies from the watchlist.
*   Added a check to see if the watchlist exceeds the limit.
*   Added `logVipError` to display errors when the watchlist exceeds the limit.
*   Implemented a user prompt to continue or skip watchlist import based on the limit.
*   Reformatted code for readability.

Technology:

This change utilizes the `fs/promises` module for file reading, and `process` for user input, and interacts with the Trakt API.

Testing:

Manual testing was performed to verify the watchlist limit and error messages.

Fixes: #2 & #3